### PR TITLE
Setting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,8 +2,9 @@ import { FlatCompat } from '@eslint/eslintrc'
 import js from '@eslint/js'
 import eslintPluginNext from '@next/eslint-plugin-next'
 import tsParser from '@typescript-eslint/parser'
-import eslintPluginReact from 'eslint-plugin-react'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import * as eslintPluginImport from 'eslint-plugin-import'
+import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import { defineConfig } from 'eslint/config'
 import path from 'node:path'
@@ -12,69 +13,70 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all
+	baseDirectory: __dirname,
+	recommendedConfig: js.configs.recommended,
+	allConfig: js.configs.all
 })
 
 export default defineConfig([
-  {
-    files: ['src/**/*.{ts,tsx}'],
-    extends: compat.extends(
-      'plugin:@typescript-eslint/recommended',
-      'next/core-web-vitals',
-      'next/typescript',
-      'prettier'
-    ),
-    languageOptions: {
-      parser: tsParser,
-      ecmaVersion: 5,
-      sourceType: 'script',
-      parserOptions: {
-        project: './tsconfig.json'
-      }
-    },
-    plugins: {
-      react: eslintPluginReact,
-      'react-hooks': eslintPluginReactHooks,
-      '@next/next': eslintPluginNext
-    },
-    rules: {
-      '@typescript-eslint/no-unused-vars': 'warn',
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unsafe-call': 'error',
-      '@typescript-eslint/no-unsafe-member-access': 'error',
-      '@typescript-eslint/no-unsafe-return': 'error',
-      ...eslintPluginReactHooks.configs.recommended.rules,
-      ...eslintPluginNext.configs.recommended.rules,
-      ...eslintPluginNext.configs['core-web-vitals'].rules,
-      'import/order': [
-        'error',
-        {
-          groups: [
-            'builtin',
-            'external',
-            'internal',
-            'parent',
-            'sibling',
-            'object',
-            'index',
-            'type'
-          ],
-          pathGroups: [
-            {
-              pattern: '{react,react-dom/**,react-router-dom}',
-              group: 'builtin',
-              position: 'before'
-            }
-          ],
-          pathGroupsExcludedImportTypes: ['builtin'],
-          alphabetize: {
-            order: 'asc'
-          }
-        }
-      ]
-    }
-  },
-  eslintConfigPrettier
+	{
+		files: ['src/**/*.{ts,tsx}'],
+		extends: compat.extends(
+			'plugin:@typescript-eslint/recommended',
+			'next/core-web-vitals',
+			'next/typescript',
+			'prettier'
+		),
+		languageOptions: {
+			parser: tsParser,
+			ecmaVersion: 5,
+			sourceType: 'script',
+			parserOptions: {
+				project: './tsconfig.json'
+			}
+		},
+		plugins: {
+			import: eslintPluginImport,
+			react: eslintPluginReact,
+			'react-hooks': eslintPluginReactHooks,
+			'@next/next': eslintPluginNext
+		},
+		rules: {
+			'@typescript-eslint/no-unused-vars': 'warn',
+			'@typescript-eslint/no-explicit-any': 'error',
+			'@typescript-eslint/no-unsafe-call': 'error',
+			'@typescript-eslint/no-unsafe-member-access': 'error',
+			'@typescript-eslint/no-unsafe-return': 'error',
+			...eslintPluginReactHooks.configs.recommended.rules,
+			...eslintPluginNext.configs.recommended.rules,
+			...eslintPluginNext.configs['core-web-vitals'].rules,
+			'import/order': [
+				'error',
+				{
+					groups: [
+						'type',
+						'builtin',
+						'external',
+						'internal',
+						'parent',
+						'sibling',
+						'object',
+						'index'
+					],
+					pathGroups: [
+						{
+							pattern: '{react,react-dom/**,react-router-dom}',
+							group: 'builtin',
+							position: 'before'
+						}
+					],
+					pathGroupsExcludedImportTypes: ['builtin'],
+					alphabetize: {
+						order: 'asc'
+					}
+				}
+			]
+		}
+	},
+	eslintConfigPrettier
 ])

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,6 +53,7 @@ export default defineConfig([
 			'import/order': [
 				'error',
 				{
+					// 自動並び替えとバッティングするので糖度調整
 					groups: [
 						'type',
 						'builtin',

--- a/package.json
+++ b/package.json
@@ -1,43 +1,44 @@
 {
-  "name": "sample-study-session",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'"
-  },
-  "dependencies": {
-    "next": "15.2.4",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "devDependencies": {
-    "@eslint/eslintrc": "^3",
-    "@eslint/js": "^9.23.0",
-    "@next/eslint-plugin-next": "^15.2.4",
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "@typescript-eslint/eslint-plugin": "^8.28.0",
-    "@typescript-eslint/parser": "^8.28.0",
-    "eslint": "^9",
-    "eslint-config-next": "15.2.4",
-    "eslint-config-prettier": "^10.1.1",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "prettier": "^3.5.3",
-    "prettier-plugin-tailwindcss": "^0.6.11",
-    "tailwindcss": "^4",
-    "typescript": "^5"
-  },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "sharp"
-    ]
-  }
+	"name": "sample-study-session",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --turbopack",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint",
+		"format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'"
+	},
+	"dependencies": {
+		"next": "15.2.4",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
+	},
+	"devDependencies": {
+		"@eslint/eslintrc": "^3",
+		"@eslint/js": "^9.23.0",
+		"@next/eslint-plugin-next": "^15.2.4",
+		"@tailwindcss/postcss": "^4",
+		"@types/node": "^20",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
+		"@typescript-eslint/eslint-plugin": "^8.28.0",
+		"@typescript-eslint/parser": "^8.28.0",
+		"eslint": "^9",
+		"eslint-config-next": "15.2.4",
+		"eslint-config-prettier": "^10.1.1",
+		"eslint-plugin-import": "^2.31.0",
+		"eslint-plugin-react": "^7.37.4",
+		"eslint-plugin-react-hooks": "^5.2.0",
+		"prettier": "^3.5.3",
+		"prettier-plugin-tailwindcss": "^0.6.11",
+		"tailwindcss": "^4",
+		"typescript": "^5"
+	},
+	"pnpm": {
+		"ignoredBuiltDependencies": [
+			"sharp"
+		]
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.1
         version: 10.1.1(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-react:
         specifier: ^7.37.4
         version: 7.37.4(eslint@9.23.0(jiti@2.4.2))


### PR DESCRIPTION
コンポーネント実装時にimport文でLintエラーが発生していたのでその解決

- 📦 : eslint-plugin-importをdevDependenciesに追加
- 🔧 : eslint.config.mjsにeslint-plugin-importを追加し、インポート順序のルールを設定
- 💡 : eslint.config.mjsの'import/order'ルールにコメントを追加説明